### PR TITLE
use </blockquote> to find end of raidlog zone section

### DIFF
--- a/kolmafia/scripts/safeDreadPreAdventure.ash
+++ b/kolmafia/scripts/safeDreadPreAdventure.ash
@@ -33,8 +33,7 @@ void safeToContinue(string zone) {
 		// logic to make sure we're not adventuring at the same time as anyone else
 
 		int startIndex = raidLogs.index_of(`The {zone}`);
-		string[string] endIndexText = {"Village":"The Woods", "Woods":"The Castle", "Castle":"Miscellaneous"};
-		int endIndex = raidLogs.index_of(endIndexText[zone]);
+		int endIndex = raidLogs.index_of("</blockquote>", startIndex);
 		// Find the start and the end of the raidlogs zone portions
 
 


### PR DESCRIPTION
The raidlog order of zones doesn't appear to be consistent enough to depend on. (Mine showed up as Woods, Village, Miscellaneous, Castle, and the script was assuming it should be Village, Woods, Castle, Miscellaneous.)

Searching for `</blockquote>` starting from the beginning of the section finds the end of the section no matter where it shows up.

💙 -- sepos (#187675)